### PR TITLE
Fix arduino restarting at new websocket session

### DIFF
--- a/raspberry/main.go
+++ b/raspberry/main.go
@@ -4,16 +4,30 @@ import (
 	"log"
 	"os"
 
+	"github.com/xTaube/vr-controlled-robot-arm/robot"
 	"github.com/xTaube/vr-controlled-robot-arm/server"
+	"go.bug.st/serial"
 )
 
 func main() {
-	// err = server.RunWebTransportServer(
-	// os.Getenv("PORT"),
-	// os.Getenv("CERT_PATH"),
-	// os.Getenv("KEY_PATH"),
-	// )
-	err := server.RunWebSocketServer(os.Getenv("PORT"))
+	log.Println("Initializing robot arm...")
+	robot, err := robot.InitRobot(
+		robot.UartConfig{
+			PortName: os.Getenv("UART_PORT"),
+			Parity:   serial.EvenParity,
+			StopBits: serial.OneStopBit,
+			BaudRate: 115200,
+			DataBits: 8,
+		},
+	)
+	if err != nil {
+		log.Printf("Error initializing robot arm: %s.\n", err)
+		return
+	}
+	defer robot.ShutDown()
+	log.Println("Robot arm initialized.")
+
+	err = server.RunWebSocketServer(os.Getenv("PORT"), robot)
 	if err != nil {
 		log.Fatalf("Failed to start server: %s", err)
 	}

--- a/raspberry/server/server.go
+++ b/raspberry/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
+	"github.com/xTaube/vr-controlled-robot-arm/robot"
 )
 
 func addWebTransportHandlers(s *webtransport.Server) {
@@ -24,12 +25,12 @@ func RunWebTransportServer(port string, certFilePath string, keyFilePath string)
 	return err
 }
 
-func addWebSocketHandlers() {
-	http.HandleFunc("/control", WebSocketControlRequestHandler)
+func addWebSocketHandlers(robot *robot.Robot) {
+	http.HandleFunc("/control", WebSocketControlRequestHandler(robot))
 }
 
-func RunWebSocketServer(port string) error {
-	addWebSocketHandlers()
+func RunWebSocketServer(port string, robot *robot.Robot) error {
+	addWebSocketHandlers(robot)
 	log.Printf("Starting server on address: :%s", port)
 	err := http.ListenAndServe(
 		fmt.Sprintf(":%s", port),

--- a/raspberry/server/workflow.go
+++ b/raspberry/server/workflow.go
@@ -114,9 +114,9 @@ func (s *XYZAxisCalibrationStep) Execute() error {
 			s.connection.WriteMessage(websocket.TextMessage, response.Parse())
 
 		default:
-			response := ErrorResponse {
+			response := ErrorResponse{
 				Code: RESPONSE_UNKNOWN_COMMAND_ERROR,
-				Err: &CommandNotFound{command},
+				Err:  &CommandNotFound{command},
 			}
 			s.connection.WriteMessage(websocket.TextMessage, response.Parse())
 		}


### PR DESCRIPTION
Make robot instance global. Arduino restarts always when uart communication starts and it's stated as a feature for easier code uploading.